### PR TITLE
在庫カレンダー画面実装と不具合修正

### DIFF
--- a/src/main/java/jp/co/metateam/library/controller/StockController.java
+++ b/src/main/java/jp/co/metateam/library/controller/StockController.java
@@ -1,6 +1,7 @@
 package jp.co.metateam.library.controller;
 
 import java.time.LocalDate;
+import java.util.Calendar;
 import java.util.List;
 
 import org.springframework.beans.factory.annotation.Autowired;
@@ -16,9 +17,11 @@ import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 
 import jakarta.validation.Valid;
 import jp.co.metateam.library.model.BookMst;
+import jp.co.metateam.library.model.BookMstDto;
 import jp.co.metateam.library.model.Stock;
 import jp.co.metateam.library.model.StockDto;
 import jp.co.metateam.library.service.BookMstService;
+import jp.co.metateam.library.model.CalendarDto;
 import jp.co.metateam.library.service.StockService;
 import jp.co.metateam.library.values.StockStatus;
 import lombok.extern.log4j.Log4j2;
@@ -133,17 +136,37 @@ public class StockController {
     }
 
     @GetMapping("/stock/calendar")
+    //メソッドがパブリックで、ビューにメソッドが文字列を返し、calendarはメソッド名
     public String calendar(@RequestParam(required = false) Integer year, @RequestParam(required = false) Integer month, Model model) {
-
+        //指定された年と月に基づいて LocalDate オブジェクトを作成
+        //year と month が null かをチェックし、どちらかが null の場合は現在の日付を使用
+        //そうでない場合は、指定された年と月を使用して指定された日付を作成。ただし、月の日付は 1 日となる
         LocalDate today = year == null || month == null ? LocalDate.now() : LocalDate.of(year, month, 1);
+
+        //ターゲットの年を設定、year が null の場合は、今日の年を使用
+        //そうでない場合は、指定された年を使用
         Integer targetYear = year == null ? today.getYear() : year;
+
+        //ターゲットの月を設定。today.getMonthValue() を使用して、今日の月を取得
         Integer targetMonth = today.getMonthValue();
 
+        //指定された年と月に基づいて、月の開始日を作成
+        //LocalDate.of(year, month, dayOfMonth) を使用して、指定された年と月の最初の日を表す LocalDate オブジェクトを作成
+        //targetYear と targetMonth が使用され、月の最初の日が設定される
         LocalDate startDate = LocalDate.of(targetYear, targetMonth, 1);
+
+        //月の日数を計算
+        //startDate.lengthOfMonth() を使用して、指定された月の日数を取得
+        //lengthOfMonth() メソッドは、指定された月の日数を返します。例）1月の場合は31、2月の場合は28または29（うるう年の場合）
         Integer daysInMonth = startDate.lengthOfMonth();
 
+        //メソッドの呼び出し
+        //与えられた年、月、開始日、および月の日数を元に、週の曜日を生成するためのメソッド
         List<Object> daysOfWeek = this.stockService.generateDaysOfWeek(targetYear, targetMonth, startDate, daysInMonth);
-        List<String> stocks = this.stockService.generateValues(targetYear, targetMonth, daysInMonth);
+        //与えられた年、月、および月の日数を元に、株の値を生成するためのメソッド
+        List<List<CalendarDto>>stocks = this.stockService.generateValues(targetYear, targetMonth, daysInMonth);
+        //書籍タイトルを取得
+        //List<BookMstDto> bookMstList = this.bookMstService.findAvailableWithStockCount();
 
         model.addAttribute("targetYear", targetYear);
         model.addAttribute("targetMonth", targetMonth);
@@ -152,6 +175,15 @@ public class StockController {
 
         model.addAttribute("stocks", stocks);
 
+
+
         return "stock/calendar";
     }
 }
+
+
+
+//書籍タイトルを取得
+        //List<BookMstDto> bookMstList = this.bookMstService.findAvailableWithStockCount();
+//書籍タイトルをモデルに追加
+        //model.addAttribute("bookMstList", bookMstList);

--- a/src/main/java/jp/co/metateam/library/model/CalendarDto.java
+++ b/src/main/java/jp/co/metateam/library/model/CalendarDto.java
@@ -1,0 +1,28 @@
+package jp.co.metateam.library.model;
+
+import java.util.Date;
+import java.util.List;
+
+import jp.co.metateam.library.model.Stock;
+import lombok.Getter;
+import lombok.Setter;
+@Getter
+@Setter
+
+public class CalendarDto {
+    private String title;
+
+    private String stockId;
+
+    private int count;
+    
+    private String availableStock;
+    
+    private Long rentalCount;
+    
+    private Long stockCountValue;
+
+    private Long stockCount;
+        
+    public Date expectedRentalOn;
+}

--- a/src/main/java/jp/co/metateam/library/model/RentalManageDto.java
+++ b/src/main/java/jp/co/metateam/library/model/RentalManageDto.java
@@ -47,13 +47,14 @@ public class RentalManageDto {
 
     private Account account;
 
+
 //貸出ステータスチェック
     public String isValidStatus(Integer previousStatus) {
 
         //RentalManage rentalManage = this.RentalManageService.findById(Long.valueOf(id));
 
-        if(previousStatus == RentalStatus.RENT_WAIT.getValue() && this.status == RentalStatus.CANCELED.getValue()) {
-            return "貸出ステータスは「貸出待ち」から「キャンセル」に変更できません";
+        if(previousStatus == RentalStatus.RENT_WAIT.getValue() && this.status == RentalStatus.RETURNED.getValue()) {
+            return "貸出ステータスは「貸出待ち」から「返却済み」に変更できません";
         }else if(previousStatus == RentalStatus.RENTAlING.getValue() && this.status == RentalStatus.RENT_WAIT.getValue()) {
             return "貸出ステータスは「貸出中」から「貸出待ち」に変更できません";
         }else if(previousStatus == RentalStatus.RENTAlING.getValue() && this.status == RentalStatus.CANCELED.getValue()) {
@@ -74,13 +75,12 @@ public class RentalManageDto {
         return null;
     }
 
-    /*if(preStatus == RentalStatus.RENT_WAIT.getValue() && this.status == RentalStatus.RENTAlING.getValue()) {
-        return null;
-    }else if(preStatus == RentalStatus.RENT_WAIT.getValue() && this.status == RentalStatus.CANCELED.getValue()) {
-       return null;
-    }else if(preStatus == RentalStatus.RENTAlING.getValue() && this.status == RentalStatus.RETURNED.getValue()) {
-        return null;
-    }else if(preStatus == RentalStatus.RENTAlING.getValue() && this.status == RentalStatus.RENT_WAIT.getValue()) {
-        return null;
+    /*public Optional<String> ValidDateTime(Date expectedRentalOn, Date expectedReturnOn) {
+ 
+        if (expectedRentalOn.compareTo(expectedReturnOn) >=0){
+ 
+            return Optional.of("「返却予定日」は「貸出予定日」より後の日付けを入力してください");
+        }
+        return Optional.empty();
     }*/
 }

--- a/src/main/java/jp/co/metateam/library/repository/BookMstRepository.java
+++ b/src/main/java/jp/co/metateam/library/repository/BookMstRepository.java
@@ -1,15 +1,16 @@
 package jp.co.metateam.library.repository;
-
+ 
 import org.springframework.data.jpa.repository.JpaRepository;
-
+import org.springframework.data.jpa.repository.Query;
 import jp.co.metateam.library.model.BookMst;
-
+ 
 import java.math.BigInteger;
 import java.util.List;
 import java.util.Optional;
-
+ 
 public interface BookMstRepository extends JpaRepository<BookMst, Long> {
-	List<BookMst> findAll();
-
-	Optional<BookMst> findById(BigInteger id);
+    List<BookMst> findAll();
+ 
+    Optional<BookMst> findById(BigInteger id);
+ 
 }

--- a/src/main/java/jp/co/metateam/library/repository/RentalManageRepository.java
+++ b/src/main/java/jp/co/metateam/library/repository/RentalManageRepository.java
@@ -8,6 +8,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
+import jp.co.metateam.library.model.BookMst;
 import jp.co.metateam.library.model.RentalManage;
 
 @Repository
@@ -31,4 +32,9 @@ public interface RentalManageRepository extends JpaRepository<RentalManage, Long
     //自分以外の期間の重複チェック
     @Query("SELECT COUNT(rm) FROM RentalManage rm WHERE rm.stock.id = ?1 AND rm.status IN (0, 1) AND rm.id <> ?2 AND (rm.expectedRentalOn > ?3 OR rm.expectedReturnOn < ?4)")
     long countByStockIdAndStatusAndIdNotAndTermsIn(String stockId, Long id, Date expectedReturnOn, Date expectedRentalOn);
+ 
+    @Query(value = "SELECT COUNT(*) FROM rental_manage rm INNER JOIN stocks s ON rm.stock_id = s.id INNER JOIN book_mst bm ON s.book_id = bm.id WHERE bm.title = ?1 AND rm.expected_rental_on <= ?2 AND rm.expected_return_on >= ?2", nativeQuery = true)
+    Long countByborrowingbook(String title, Date specifiedDate);
+
+    //？は値が変わる
 }

--- a/src/main/java/jp/co/metateam/library/repository/StockRepository.java
+++ b/src/main/java/jp/co/metateam/library/repository/StockRepository.java
@@ -1,10 +1,16 @@
 package jp.co.metateam.library.repository;
 
+import java.util.Date;
 import java.util.List;
 import java.util.Optional;
 
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+import org.springframework.data.repository.query.Param;
 
 import jp.co.metateam.library.model.Stock;
 
@@ -20,4 +26,14 @@ public interface StockRepository extends JpaRepository<Stock, Long> {
 	Optional<Stock> findById(String id);
     
     List<Stock> findByBookMstIdAndStatus(Long book_id,Integer status);
+
+    @Query("SELECT bm.bookMst.title, COUNT(bm) FROM Stock bm JOIN bm.bookMst WHERE bm.status = 0 AND bm.deletedAt IS NULL GROUP BY bm.bookMst.title")
+    List<Object[]> findByBookMstIdAndStatus();
+
+    @Query("SELECT s.id FROM Stock s WHERE s.bookMst.title = :title")
+    String findStockIdByTitle(@Param("title") String title);
+
+
+
 }
+

--- a/src/main/java/jp/co/metateam/library/service/StockService.java
+++ b/src/main/java/jp/co/metateam/library/service/StockService.java
@@ -1,32 +1,45 @@
 package jp.co.metateam.library.service;
 
 import java.time.LocalDate;
+import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
+import java.util.Calendar;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Random;
+import java.util.Date;
 
+import org.hibernate.sql.ast.tree.insert.Values;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import jp.co.metateam.library.constants.Constants;
+import jp.co.metateam.library.controller.StockController;
 import jp.co.metateam.library.model.BookMst;
+import jp.co.metateam.library.model.CalendarDto;
 import jp.co.metateam.library.model.Stock;
 import jp.co.metateam.library.model.StockDto;
 import jp.co.metateam.library.repository.BookMstRepository;
+import jp.co.metateam.library.repository.RentalManageRepository;
 import jp.co.metateam.library.repository.StockRepository;
 
 @Service
 public class StockService {
     private final BookMstRepository bookMstRepository;
     private final StockRepository stockRepository;
+    private final RentalManageRepository rentalManageRepository;
+    private String bookTitle;
+    private Object rentalStatus;
 
     @Autowired
-    public StockService(BookMstRepository bookMstRepository, StockRepository stockRepository){
+    public StockService(BookMstRepository bookMstRepository, StockRepository stockRepository,
+            RentalManageRepository rentalManageRepository) {
         this.bookMstRepository = bookMstRepository;
         this.stockRepository = stockRepository;
+        this.rentalManageRepository = rentalManageRepository;
     }
 
     @Transactional
@@ -35,10 +48,10 @@ public class StockService {
 
         return stocks;
     }
-    
+
     @Transactional
-    public List <Stock> findStockAvailableAll() {
-        List <Stock> stocks = this.stockRepository.findByDeletedAtIsNullAndStatus(Constants.STOCK_AVAILABLE);
+    public List<Stock> findStockAvailableAll() {
+        List<Stock> stocks = this.stockRepository.findByDeletedAtIsNullAndStatus(Constants.STOCK_AVAILABLE);
 
         return stocks;
     }
@@ -48,7 +61,7 @@ public class StockService {
         return this.stockRepository.findById(id).orElse(null);
     }
 
-    @Transactional 
+    @Transactional
     public void save(StockDto stockDto) throws Exception {
         try {
             Stock stock = new Stock();
@@ -69,7 +82,7 @@ public class StockService {
         }
     }
 
-    @Transactional 
+    @Transactional
     public void update(String id, StockDto stockDto) throws Exception {
         try {
             Stock stock = findById(id);
@@ -94,10 +107,15 @@ public class StockService {
         }
     }
 
+    // 指定された年、月、開始日、および月の日数を受け取り、週の日付を生成
     public List<Object> generateDaysOfWeek(int year, int month, LocalDate startDate, int daysInMonth) {
+        // 日付を格納するための新しいリストを作成
         List<Object> daysOfWeek = new ArrayList<>();
+        // 1から月の日数までのループ
         for (int dayOfMonth = 1; dayOfMonth <= daysInMonth; dayOfMonth++) {
+            // 現在の年、月、およびループのカウンターである日を使用して、LocalDateオブジェクトを生成
             LocalDate date = LocalDate.of(year, month, dayOfMonth);
+            // 日付をフォーマットするためのDateTimeFormatterオブジェクトを作成
             DateTimeFormatter formmater = DateTimeFormatter.ofPattern("dd(E)", Locale.JAPANESE);
             daysOfWeek.add(date.format(formmater));
         }
@@ -105,19 +123,88 @@ public class StockService {
         return daysOfWeek;
     }
 
-    public List<String> generateValues(Integer year, Integer month, Integer daysInMonth) {
-        // FIXME ここで各書籍毎の日々の在庫を生成する処理を実装する
-        // FIXME ランダムに値を返却するサンプルを実装している
-        String[] stockNum = {"1", "2", "3", "4", "×"};
-        Random rnd = new Random();
-        List<String> values = new ArrayList<>();
-        values.add("スッキリわかるJava入門 第4版"); // 対象の書籍名
-        values.add("10"); // 対象書籍の在庫総数
-        
-        for (int i = 1; i <= daysInMonth; i++) {
-            int index = rnd.nextInt(stockNum.length);
-            values.add(stockNum[index]);
-        }
-        return values;
-    }
-}
+    public List<List<CalendarDto>> generateValues(Integer year, Integer month, Integer daysInMonth) {
+
+        // リスト(大きな箱)作成
+        List<List<CalendarDto>> bigValues = new ArrayList<>();
+        // 書籍名と利用可能在庫数を取得
+        List<Object[]> stockCount = this.stockRepository.findByBookMstIdAndStatus();
+
+        for (Object[] bookIn : stockCount) {
+            // 書籍タイトルを取得
+            String bookTitle = (String) bookIn[0];
+            // 在庫数を取得
+            Long stockCountValue = (Long) bookIn[1];
+            // 取得した書籍名と在庫数をリストに追加
+            List<CalendarDto> abkList = new ArrayList<>();
+
+
+            // 日付ループ
+            // 1日から月の最終日までの日数をループ
+            for (int daysLastMonth = 1; daysLastMonth <= daysInMonth; daysLastMonth++) {
+                // オブジェクト作成
+                LocalDate date = LocalDate.of(year, month, daysLastMonth);
+                // 12時から日付が変わるようDate型に変換（時間設定）
+                Date atDate = Date.from(date.atStartOfDay(ZoneId.systemDefault()).toInstant());
+                // 利用可能なStockIdを取得
+                Long rentalCount = this.rentalManageRepository.countByborrowingbook(bookTitle, atDate);
+                // 貸出待ちまたは貸出中のステータスを取得（詳細設計変更箇所）
+
+                // 利用可能在庫数から貸出数を引く
+                Long availableCount = stockCountValue - rentalCount;
+
+                CalendarDto calendarDto = new CalendarDto();
+                calendarDto.setStockCountValue(stockCountValue);
+                calendarDto.setRentalCount(rentalCount);
+                calendarDto.setTitle(bookTitle);
+                calendarDto.setExpectedRentalOn(atDate);
+
+                // 利用可能在庫数が０の場合「×」
+                if (availableCount <= 0) {
+                    calendarDto.setAvailableStock("×");
+                } else {
+                    calendarDto.setAvailableStock(String.valueOf(availableCount));
+                }
+                
+                // add
+                abkList.add(calendarDto);
+                }
+                bigValues.add(abkList);
+                }
+                return bigValues;
+            }
+}    
+    
+
+
+// FIXME ここで各書籍毎の日々の在庫を生成する処理を実装する
+// FIXME ランダムに値を返却するサンプルを実装している
+// String[] stockNum = {"1", "2", "3", "4", "×"};
+// Random rnd = new Random();
+// List<String> values = new ArrayList<>();
+// values.add("スッキリわかるJava入門 第4版"); // 対象の書籍名
+// values.add("10"); // 対象書籍の在庫総数
+
+// for (int dayOfMonth = 1; dayOfMonth <= daysInMonth; dayOfMonth++) {
+// int index = rnd.nextInt(stockNum.length);
+// values.add(stockNum[index]);
+// }
+// return values;
+// }
+
+/*
+ * String title = lendableTitles.get(i);
+ * //リストから、現在のループで処理するタイトルに対応する情報を取得
+ * //タイトルごとの貸し出し可能な本の数の情報を含む配列
+ * Object[] bookInfo = countBylendableBooks.get(i);
+ * //配列から、貸し出し可能な本の数を取得
+ * Long count = (Long) bookInfo[1];
+ * //リストにタイトルを追加
+ * values.add(title);
+ * //貸し出し可能な本の数を文字列に変換し、valuesリストに追加
+ * values.add(count.toString());
+ */
+// データベースからデータを取得
+// List<String> lendableTitles = this.stockRepository.findByLendableTitle();
+// List<Object[]> countBylendableBooks =
+// this.stockRepository.countByLendableBook();

--- a/src/main/resources/templates/rental/edit.html
+++ b/src/main/resources/templates/rental/edit.html
@@ -20,7 +20,7 @@
                         <a th:href="@{/rental/index}" class="link">← 一覧へ戻る</a>
                     </span>
                 </div>
-                <form id="rental_edit_form" th:object="${rentalManageDto}" th:action="@{/rental/{id}/edit(id=*{id})}" method="post">
+                <form id="rental_edit_form" th:object="${rentalManageDto}" th:action="@{/rental/{id}/edit(id=*{id})}" method="post"novalidate>
                     <div class="mb30">
                         <label class="input_title" for="employeeId">社員番号<span class="text-red asterisk">＊</span></label>
                         <select id="employeeId" class="form_input" name="employeeId" required>

--- a/src/main/resources/templates/stock/calendar.html
+++ b/src/main/resources/templates/stock/calendar.html
@@ -1,10 +1,12 @@
 <!DOCTYPE html>
 <html lang="ja" xmlns:th="http://www.thymeleaf.org">
+
 <head th:replace="~{common :: meta_header('在庫カレンダー',~{::link},~{::script})}">
     <title th:text="${title}+' | MTLibrary'"></title>
     <link rel="stylesheet" th:href="@{/css/stock/calendar.css}" />
     <script type="text/javascript" th:src="@{/js/stock/add.js}"></script>
 </head>
+
 <body>
     <div class="contents">
         <div th:replace="~{common :: main_sidebar}"></div>
@@ -29,16 +31,25 @@
                             <tr>
                                 <th class="header_book" rowspan="2">書籍名</th>
                                 <th class="header_stock" rowspan="2">在庫数</th>
-                                <th class="header_days" th:colspan="${daysInMonth}" th:text="${targetYear + '年' + targetMonth + '月'}"></th>
+                                <th class="header_days" th:colspan="${daysInMonth}"
+                                    th:text="${targetYear + '年' + targetMonth + '月'}"></th>
                             </tr>
                             <tr class="days">
                                 <th th:each="day : ${daysOfWeek}" th:text="${day}"></th>
                             </tr>
                         </thead>
                         <tbody>
-                            <tr>
+                            <tr th:each="stockList: ${stocks}">
                                 <!-- FIXME ControllerやService側の処理とともに表示方法を考える -->
-                                <td th:each="stock, stat : ${stocks}" th:text="${stock}"></td>
+                                <td th:text="${stockList[0].title}"></td> <!-- 一つ目の値 -->
+                                <td th:text="${stockList[0].stockCountValue}"></td> <!-- 二つ目の値 -->
+                                <td th:each="value : ${stockList}">
+                                    <span th:if="${value.availableStock == '×'}"
+                                        th:text="${value.availableStock}"></span>
+                                    <a th:if="${value.availableStock != '×'}"
+                                        th:href="@{/rental/add(stockId=${value.stockId}, expectedRentalOn=${#dates.format(value.expectedRentalOn, 'yyyy-MM-dd')})}"
+                                        th:text="${value.availableStock}"></a>
+                                </td>
                             </tr>
                         </tbody>
                     </table>

--- a/src/main/resources/templates/stock/edit.html
+++ b/src/main/resources/templates/stock/edit.html
@@ -22,7 +22,7 @@
                 </div>
 
                 <form id="stock_edit_form" th:object="${stockDto}" th:action="@{/stock/{id}/edit(id=*{id})}"
-                    method="post">
+                    method="post" >
                     <div class="mb30">
                         <label for="bookSelector">書籍名</label>
                         <div th:text="${stockDto.bookMst.title}"></div>


### PR DESCRIPTION
概要】
・在庫カレンダーの実装
・書籍名ごとの利用可能在庫数とその日ごとの貸出可能数の表示
・日ごとの貸出可能数のリンクを押下時、貸出登録画面に遷移

【証跡】
・在庫カレンダーを押下し、書籍名と利用可能在庫数を確認
・書籍を借りたい日のリンク押下
・貸出登録画面に遷移